### PR TITLE
map_nameを引数に，パラメータにセットされるように実装（env_manageで取得する用途）

### DIFF
--- a/augment_gridmap_online/src/augment_gridmap_online_node.cpp
+++ b/augment_gridmap_online/src/augment_gridmap_online_node.cpp
@@ -35,6 +35,7 @@ public:
     this->declare_parameter("furniture_pkg", "");
     this->declare_parameter("furniture_path", "");
     this->declare_parameter("furniture_yaml_file", "");
+    this->declare_parameter("map_name", std::string(""));
 
     this->get_parameter("use_namespace", use_namespace_);
     this->get_parameter("obstacle_radius", obstacle_radius_);

--- a/navigation_start/launch/navigation.launch.xml
+++ b/navigation_start/launch/navigation.launch.xml
@@ -80,6 +80,7 @@
     <param name="obstacle_radius" value="0.05"/>
     <param name="debug" value="True"/>
     <param name="input_map" value="/fixed_prohibition_layer_map"/>
+    <param name="map_name" value="$(var map_name)"/>
     <!-- Static furniture obstacles. The node skips the loader entirely when
          add_static_obstacles is false, so the env_furniture_pkg package only
          needs to exist at runtime when add_static_obstacles is true. -->


### PR DESCRIPTION
[新mapのアップとRVizでcollisionサーバのトピック購読，map_nameをnavigation.launch.xmlの引数に追加](https://github.com/Hibikino-Musashi-Home/hma_hsr_navigation2/pull/10) と[map_nameをNavigationから取得するように実装（上書きしたい場合は引数指定することも可）](https://github.com/Hibikino-Musashi-Home/hma_env_manage2/pull/23)に関連したPR
