### PR TITLE
Implement GazePoint

### DIFF
--- a/hardware_controller/CMakeLists.txt
+++ b/hardware_controller/CMakeLists.txt
@@ -31,6 +31,9 @@ add_executable(arm_node
 add_executable(head_node
     src/head_node.cpp
 )
+add_executable(gaze_node
+    src/gaze_node.cpp
+)
 
 ament_target_dependencies(arm_node
     rclcpp
@@ -66,6 +69,16 @@ ament_target_dependencies(head_node
     pumas_interfaces
 )
 
+ament_target_dependencies(gaze_node
+    rclcpp
+
+    std_msgs
+    geometry_msgs
+
+    tf2
+    tf2_ros
+)
+
 
 # Python section
 ament_python_install_package(${PROJECT_NAME})
@@ -82,6 +95,10 @@ arm_node
 )
 install(TARGETS
 head_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+install(TARGETS
+gaze_node
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/hardware_controller/CMakeLists.txt
+++ b/hardware_controller/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(tf2_ros REQUIRED)
 
 find_package(rcl_interfaces REQUIRED)
 find_package(pumas_interfaces REQUIRED)
+find_package(rclcpp_action REQUIRED)
 
 # C++ section
 add_executable(arm_node
@@ -71,12 +72,15 @@ ament_target_dependencies(head_node
 
 ament_target_dependencies(gaze_node
     rclcpp
+    rclcpp_action
 
     std_msgs
     geometry_msgs
 
     tf2
     tf2_ros
+
+    pumas_interfaces
 )
 
 

--- a/hardware_controller/package.xml
+++ b/hardware_controller/package.xml
@@ -21,6 +21,7 @@
   <depend>std_srvs</depend>
   <depend>action_msgs</depend>
   <depend>actionlib_msgs</depend>
+  <depend>rclcpp_action</depend>
   
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/hardware_controller/src/gaze_node.cpp
+++ b/hardware_controller/src/gaze_node.cpp
@@ -1,0 +1,143 @@
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/executors/multi_threaded_executor.hpp>
+
+#include <std_msgs/msg/float32_multi_array.hpp>
+
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2/exceptions.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include <string>
+#include <cmath>
+
+class GazeController : public rclcpp::Node
+{
+public:
+  GazeController()
+  : Node("gaze_controller"),
+    tf_buffer_(this->get_clock()),
+    tf_listener_(tf_buffer_)
+  {
+    this->declare_parameter<bool>(        "use_namespace",  false);
+    this->declare_parameter<std::string>( "gaze_tf_name",   "gaze_point");
+    this->declare_parameter<std::string>( "base_link_name", "base_footprint");
+    this->declare_parameter<double>(      "head_height",    1.1);
+
+    this->get_parameter("use_namespace",  use_namespace_);
+    this->get_parameter("gaze_tf_name",   gaze_tf_name_);
+    this->get_parameter("base_link_name", base_link_name_);
+    this->get_parameter("head_height",    head_height_);
+
+    pub_head_goal_pose_ = this->create_publisher<std_msgs::msg::Float32MultiArray>(
+      make_name("/hardware/head/goal_pose"),
+      rclcpp::QoS(10).transient_local());
+
+    timer_ = this->create_wall_timer(
+      std::chrono::milliseconds(100),
+      std::bind(&GazeController::timerCallback, this));
+
+    RCLCPP_INFO(this->get_logger(), "GazeController.-> Node has been started.");
+  }
+
+private:
+  bool        use_namespace_ = false;
+  std::string gaze_tf_name_;
+  std::string base_link_name_;
+  double      head_height_;
+
+  tf2_ros::Buffer            tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+
+  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr pub_head_goal_pose_;
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  std::string make_name(const std::string &suffix) const
+  {
+    std::string sfx = suffix;
+    if (!sfx.empty() && sfx.front() != '/')
+      sfx = "/" + sfx;
+
+    std::string name;
+    if (use_namespace_) {
+      name = this->get_namespace() + sfx;
+      if (name.size() > 1 && name[0] == '/' && name[1] == '/')
+        name.erase(0, 1);
+    } else {
+      name = sfx;
+    }
+    return name;
+  }
+
+  // Look up gaze_tf_name in the map frame and compute [pan, tilt] head angles.
+  // Returns false and leaves msg unchanged when any TF lookup fails.
+  bool gaze_point_to_goal_head_angles(
+    std_msgs::msg::Float32MultiArray &msg,
+    const std::string &gaze_tf_name = "gaze_point")
+  {
+    try {
+      // Robot pose in map frame
+      geometry_msgs::msg::TransformStamped robot_tf =
+        tf_buffer_.lookupTransform("map", base_link_name_, tf2::TimePointZero);
+
+      float robot_x = static_cast<float>(robot_tf.transform.translation.x);
+      float robot_y = static_cast<float>(robot_tf.transform.translation.y);
+
+      tf2::Quaternion q(
+        robot_tf.transform.rotation.x,
+        robot_tf.transform.rotation.y,
+        robot_tf.transform.rotation.z,
+        robot_tf.transform.rotation.w);
+      double roll, pitch, yaw;
+      tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
+      float robot_t = static_cast<float>(yaw);
+
+      // Gaze point in map frame
+      geometry_msgs::msg::TransformStamped gaze_tf =
+        tf_buffer_.lookupTransform("map", gaze_tf_name, tf2::TimePointZero);
+
+      float gaze_x = static_cast<float>(gaze_tf.transform.translation.x);
+      float gaze_y = static_cast<float>(gaze_tf.transform.translation.y);
+      float gaze_z = static_cast<float>(gaze_tf.transform.translation.z);
+
+      // Pan: horizontal angle from robot heading toward gaze point
+      float pan = atan2(gaze_y - robot_y, gaze_x - robot_x) - robot_t;
+      if (pan >  M_PI) pan -= 2.0f * M_PI;
+      if (pan <= -M_PI) pan += 2.0f * M_PI;
+
+      // Tilt: vertical angle from head height toward gaze point
+      float dx = gaze_x - robot_x;
+      float dy = gaze_y - robot_y;
+      float h_dist = std::sqrt(dx * dx + dy * dy);
+      float tilt = std::atan2(gaze_z - static_cast<float>(head_height_), h_dist);
+
+      msg.data = {pan, tilt};
+      return true;
+    }
+    catch (const tf2::TransformException &ex) {
+      RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 2000,
+        "GazeController.-> TF lookup failed: %s", ex.what());
+      return false;
+    }
+  }
+
+  void timerCallback()
+  {
+    std_msgs::msg::Float32MultiArray msg;
+    if (gaze_point_to_goal_head_angles(msg, gaze_tf_name_))
+      pub_head_goal_pose_->publish(msg);
+  }
+};
+
+int main(int argc, char **argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<GazeController>();
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(node);
+  executor.spin();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/hardware_controller/src/gaze_node.cpp
+++ b/hardware_controller/src/gaze_node.cpp
@@ -1,5 +1,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/executors/multi_threaded_executor.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
 
 #include <std_msgs/msg/float32_multi_array.hpp>
 
@@ -10,12 +11,20 @@
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 
+#include <pumas_interfaces/action/gaze_head.hpp>
+
 #include <string>
 #include <cmath>
+#include <thread>
+#include <chrono>
+
 
 class GazeController : public rclcpp::Node
 {
 public:
+  using GazeHead       = pumas_interfaces::action::GazeHead;
+  using GoalHandleGaze = rclcpp_action::ServerGoalHandle<GazeHead>;
+
   GazeController()
   : Node("gaze_controller"),
     tf_buffer_(this->get_clock()),
@@ -33,13 +42,21 @@ public:
 
     pub_head_goal_pose_ = this->create_publisher<std_msgs::msg::Float32MultiArray>(
       make_name("/hardware/head/goal_pose"),
-      rclcpp::QoS(10).transient_local());
+      rclcpp::QoS(10).reliable());
 
-    timer_ = this->create_wall_timer(
-      std::chrono::milliseconds(100),
-      std::bind(&GazeController::timerCallback, this));
+    // Action server on /gaze_head.
+    // execute() runs in a detached thread so it can block without starving
+    // the TF listener subscription that the MultiThreadedExecutor serves.
+    action_server_ = rclcpp_action::create_server<GazeHead>(
+      this,
+      "gaze_head",
+      std::bind(&GazeController::handle_goal,     this,
+                std::placeholders::_1, std::placeholders::_2),
+      std::bind(&GazeController::handle_cancel,   this, std::placeholders::_1),
+      std::bind(&GazeController::handle_accepted, this, std::placeholders::_1));
 
-    RCLCPP_INFO(this->get_logger(), "GazeController.-> Node has been started.");
+    RCLCPP_INFO(this->get_logger(),
+      "GazeController.-> Action server ready on /gaze_head");
   }
 
 private:
@@ -52,7 +69,7 @@ private:
   tf2_ros::TransformListener tf_listener_;
 
   rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr pub_head_goal_pose_;
-  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp_action::Server<GazeHead>::SharedPtr action_server_;
 
   std::string make_name(const std::string &suffix) const
   {
@@ -71,14 +88,13 @@ private:
     return name;
   }
 
-  // Look up gaze_tf_name in the map frame and compute [pan, tilt] head angles.
-  // Returns false and leaves msg unchanged when any TF lookup fails.
-  bool gaze_point_to_goal_head_angles(
+  // Compute [pan, tilt] toward gaze_tf_name in the map frame.
+  // Returns false (and leaves msg unchanged) when any TF lookup fails.
+  bool gaze_point_to_head_angles(
     std_msgs::msg::Float32MultiArray &msg,
-    const std::string &gaze_tf_name = "gaze_point")
+    const std::string &gaze_tf_name)
   {
     try {
-      // Robot pose in map frame
       geometry_msgs::msg::TransformStamped robot_tf =
         tf_buffer_.lookupTransform("map", base_link_name_, tf2::TimePointZero);
 
@@ -94,7 +110,6 @@ private:
       tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
       float robot_t = static_cast<float>(yaw);
 
-      // Gaze point in map frame
       geometry_msgs::msg::TransformStamped gaze_tf =
         tf_buffer_.lookupTransform("map", gaze_tf_name, tf2::TimePointZero);
 
@@ -102,16 +117,14 @@ private:
       float gaze_y = static_cast<float>(gaze_tf.transform.translation.y);
       float gaze_z = static_cast<float>(gaze_tf.transform.translation.z);
 
-      // Pan: horizontal angle from robot heading toward gaze point
       float pan = atan2(gaze_y - robot_y, gaze_x - robot_x) - robot_t;
       if (pan >  M_PI) pan -= 2.0f * M_PI;
       if (pan <= -M_PI) pan += 2.0f * M_PI;
 
-      // Tilt: vertical angle from head height toward gaze point
-      float dx = gaze_x - robot_x;
-      float dy = gaze_y - robot_y;
+      float dx     = gaze_x - robot_x;
+      float dy     = gaze_y - robot_y;
       float h_dist = std::sqrt(dx * dx + dy * dy);
-      float tilt = std::atan2(gaze_z - static_cast<float>(head_height_), h_dist);
+      float tilt   = std::atan2(gaze_z - static_cast<float>(head_height_), h_dist);
 
       msg.data = {pan, tilt};
       return true;
@@ -123,11 +136,65 @@ private:
     }
   }
 
-  void timerCallback()
+  // ---------- Action server callbacks ----------
+  rclcpp_action::GoalResponse handle_goal(
+    const rclcpp_action::GoalUUID &,
+    std::shared_ptr<const GazeHead::Goal> goal)
   {
-    std_msgs::msg::Float32MultiArray msg;
-    if (gaze_point_to_goal_head_angles(msg, gaze_tf_name_))
-      pub_head_goal_pose_->publish(msg);
+    const std::string tf_name =
+      goal->gaze_tf_name.empty() ? gaze_tf_name_ : goal->gaze_tf_name;
+    RCLCPP_INFO(this->get_logger(),
+      "GazeController.-> Goal received. TF target: '%s'", tf_name.c_str());
+    return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+  }
+
+  rclcpp_action::CancelResponse handle_cancel(
+    const std::shared_ptr<GoalHandleGaze>)
+  {
+    RCLCPP_INFO(this->get_logger(), "GazeController.-> Cancel requested.");
+    return rclcpp_action::CancelResponse::ACCEPT;
+  }
+
+  void handle_accepted(const std::shared_ptr<GoalHandleGaze> goal_handle)
+  {
+    std::thread([this, goal_handle]() { execute(goal_handle); }).detach();
+  }
+
+  // Main gaze loop. Runs in a detached thread; publishes head angle commands
+  // at 100 ms intervals until canceled or the node shuts down.
+  void execute(const std::shared_ptr<GoalHandleGaze> goal_handle)
+  {
+    const auto goal = goal_handle->get_goal();
+    const std::string tf_name =
+      goal->gaze_tf_name.empty() ? gaze_tf_name_ : goal->gaze_tf_name;
+
+    RCLCPP_INFO(this->get_logger(),
+      "GazeController.-> Gaze started. Target TF: '%s'", tf_name.c_str());
+
+    auto feedback = std::make_shared<GazeHead::Feedback>();
+    auto result   = std::make_shared<GazeHead::Result>();
+
+    while (rclcpp::ok()) {
+      if (goal_handle->is_canceling()) {
+        result->success = false;
+        goal_handle->canceled(result);
+        RCLCPP_INFO(this->get_logger(), "GazeController.-> Gaze canceled.");
+        return;
+      }
+
+      std_msgs::msg::Float32MultiArray msg;
+      if (gaze_point_to_head_angles(msg, tf_name)) {
+        pub_head_goal_pose_->publish(msg);
+        feedback->pan  = msg.data[0];
+        feedback->tilt = msg.data[1];
+        goal_handle->publish_feedback(feedback);
+      }
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    result->success = false;
+    goal_handle->abort(result);
   }
 };
 

--- a/hardware_controller/src/head_node.cpp
+++ b/hardware_controller/src/head_node.cpp
@@ -33,6 +33,7 @@ public:
     this->declare_parameter<double>("pan_max", 1.74);
     this->declare_parameter<double>("tilt_min", -0.9);
     this->declare_parameter<double>("tilt_max", 0.47);
+    this->declare_parameter<bool>("move_head", true);
 
 
     // Initialize internal variables from declared parameters
@@ -46,6 +47,7 @@ public:
     this->get_parameter("pan_max", pan_max_);
     this->get_parameter("tilt_min", tilt_min_);
     this->get_parameter("tilt_max", tilt_max_);
+    this->get_parameter("move_head", move_head_);
 
     // Setup parameter change callback
     param_callback_handle_ = this->add_on_set_parameters_callback(
@@ -102,6 +104,7 @@ private:
   std::string head_goal_reached_topic_;
 
   double pan_min_, pan_max_, tilt_min_, tilt_max_;
+  bool   move_head_ = true;
 
   rclcpp::Publisher<trajectory_msgs::msg::JointTrajectory>::SharedPtr  pub_head_goal_traj_;
   rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr       pub_head_current_pose_;
@@ -145,6 +148,14 @@ private:
       else if (param.get_name() == "head_goal_topic")         head_goal_topic_          = param.as_string();
       else if (param.get_name() == "head_current_topic")      head_current_topic_       = param.as_string();
       else if (param.get_name() == "head_goal_reached_topic") head_goal_reached_topic_  = param.as_string();
+
+      else if (param.get_name() == "move_head") {
+        move_head_ = param.as_bool();
+        RCLCPP_INFO(this->get_logger(),
+          "HeadController.-> move_head set to %s",
+          move_head_ ? "true (motion_synth head enabled)"
+                     : "false (gaze controller owns head)");
+      }
 
       else {
         result.successful = false;
@@ -238,6 +249,12 @@ private:
 
   void motionPoseCallback(const pumas_interfaces::msg::MotionPose::SharedPtr msg)
   {
+    if (!move_head_) {
+      RCLCPP_DEBUG(this->get_logger(),
+        "head_node.-> move_head=false: ignoring motion_pose head command (gaze active)");
+      return;
+    }
+
     head_time_from_start_ = (msg->motion_execution_time > 0.0f)
         ? static_cast<double>(msg->motion_execution_time)
         : kDefaultHeadTimeFromStart;

--- a/navigation_start/launch/navigation.launch.xml
+++ b/navigation_start/launch/navigation.launch.xml
@@ -57,7 +57,7 @@
   <arg name="add_static_obstacles" default="True"/>
   <arg name="env_furniture_pkg" default="hma_env_manage2"/>
   <arg name="env_furniture_file" default="env_furniture_$(var map_name)"/> <!--change your env_furniture-->
-
+  <arg name="move_head" default="True"/>
   <!-- Map servers -->
   <node name="static_map_server" pkg="nav2_map_server" exec="map_server" output="screen" respawn="true">
     <param name="yaml_filename" value="$(var static_map_file)"/>
@@ -155,7 +155,7 @@
     <param name="max_angular_speed" value="1.25"/>
     <param name="control_alpha" value="0.2"/>
     <param name="control_beta" value="0.8"/>
-    <param name="move_head" value="True"/>
+    <param name="move_head" value="$(var move_head)"/>
     <param name="use_pot_fields" value="$(var use_pot_fields)"/>
     <remap from="/cmd_vel" to="$(var cmd_vel_topic)"/>
   </node>

--- a/navigation_start/launch/navigation.launch.xml
+++ b/navigation_start/launch/navigation.launch.xml
@@ -225,6 +225,11 @@
     <param name="tilt_min" value="-0.7"/>
     <param name="tilt_max" value="0.47"/>
   </node>
+  <node name="gaze_controller" pkg="hardware_controller" exec="gaze_node" output="screen" respawn="true">
+    <param name="gaze_tf_name"   value="gaze_point"/>
+    <param name="base_link_name" value="base_footprint"/>
+    <param name="head_height"    value="1.1"/>
+  </node>
 
   <!-- RVIZ2 -->
   <node name="rviz2" pkg="rviz2" exec="rviz2" args="-d $(find-pkg-share navigation_start)/rviz/config.rviz               --ros-args --log-level rviz2:=warn" output="screen"/>

--- a/navigation_tools/CMakeLists.txt
+++ b/navigation_tools/CMakeLists.txt
@@ -68,6 +68,11 @@ install(PROGRAMS
   DESTINATION lib/${PROJECT_NAME}
 )
 
+install(PROGRAMS
+  ${PROJECT_NAME}/gaze_tf_broadcaster.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 # Ensure both are included
 #install(TARGETS
 #_node

--- a/navigation_tools/navigation_tools/gaze_tf_broadcaster.py
+++ b/navigation_tools/navigation_tools/gaze_tf_broadcaster.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# test node use for gaze node
+
+import rclpy
+from geometry_msgs.msg import TransformStamped
+from rclpy.node import Node
+from tf2_ros import TransformBroadcaster
+
+
+class GazeTfBroadcaster(Node):
+    def __init__(self):
+        super().__init__('gaze_tf_broadcaster')
+
+        self.declare_parameter('parent_frame', 'map')
+        self.declare_parameter('child_frame', 'gaze_point')
+        self.declare_parameter('x', 2.0)
+        self.declare_parameter('y', 0.0)
+        self.declare_parameter('z', 1.0)
+        self.declare_parameter('rate_hz', 20.0)
+
+        self.parent_frame = self.get_parameter('parent_frame').value
+        self.child_frame = self.get_parameter('child_frame').value
+        rate_hz = float(self.get_parameter('rate_hz').value)
+
+        self.broadcaster = TransformBroadcaster(self)
+        self.timer = self.create_timer(1.0 / rate_hz, self.broadcast)
+
+        self.get_logger().info(
+            f'GazeTfBroadcaster.-> publishing {self.parent_frame} -> '
+            f'{self.child_frame} at {rate_hz:.0f} Hz'
+        )
+
+    def broadcast(self):
+        t = TransformStamped()
+        t.header.stamp = self.get_clock().now().to_msg()
+        t.header.frame_id = self.parent_frame
+        t.child_frame_id = self.child_frame
+        t.transform.translation.x = float(self.get_parameter('x').value)
+        t.transform.translation.y = float(self.get_parameter('y').value)
+        t.transform.translation.z = float(self.get_parameter('z').value)
+        t.transform.rotation.w = 1.0
+        self.broadcaster.sendTransform(t)
+
+
+def main():
+    rclpy.init()
+    node = GazeTfBroadcaster()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/navigation_tools/navigation_tools/navlib.py
+++ b/navigation_tools/navigation_tools/navlib.py
@@ -9,7 +9,7 @@ import numpy as np
 import rclpy
 import tf2_ros
 from geometry_msgs.msg import Pose2D, PoseStamped
-from pumas_interfaces.action import PumasNav
+from pumas_interfaces.action import GazeHead, PumasNav
 from pumas_interfaces.msg import Joints, StartAndEndJoints
 from pumas_interfaces.srv import ParamReadWrite
 from rclpy.action import ActionClient
@@ -94,6 +94,12 @@ class NavModule:
         self._action_near_goal = False
         self._action_message = ''
 
+        # Gaze action client
+        self.gaze_action_client = ActionClient(
+            self._node, GazeHead, '/gaze_head')
+        self._gaze_goal_handle = None
+        self._gaze_active = False
+
         self.tf_buffer = tf2_ros.Buffer()
         self.tf_listener = tf2_ros.TransformListener(
             self.tf_buffer, self._node)
@@ -143,6 +149,10 @@ class NavModule:
     def nav_feedback_callback(self, feedback_msg):
         feedback = feedback_msg.feedback
         self._action_feedback = feedback
+        # Latch near_goal flag from feedback so go_abs() can cancel gaze
+        # mid-navigation before the result arrives.
+        if feedback.near_goal_reached:
+            self._action_near_goal = True
         self.get_logger().info(
             f'Nav feedback: state={feedback.state_name}, '
             f'dist={feedback.remaining_distance:.3f}, '
@@ -175,6 +185,71 @@ class NavModule:
         if self._goal_handle is not None:
             self.get_logger().warn('NavModule.->Canceling PumasNav goal')
             self._goal_handle.cancel_goal_async()
+
+    # ---------- Gaze management ----------
+    def _gaze_goal_response_callback(self, future):
+        goal_handle = future.result()
+        if goal_handle is None or not goal_handle.accepted:
+            self.get_logger().warn('NavModule.->GazeHead goal rejected')
+            self._gaze_active = False
+            return
+        self._gaze_goal_handle = goal_handle
+        self._gaze_active = True
+        self.get_logger().info('NavModule.->GazeHead goal accepted, gaze active')
+
+    def start_gaze(self, gaze_tf_name: str = '') -> bool:
+        """Send a GazeHead goal (fire-and-forget). Returns False when the
+        action server is unreachable within 3 s."""
+        if not self.gaze_action_client.wait_for_server(timeout_sec=3.0):
+            self.get_logger().warn(
+                'NavModule.->GazeHead action server not available')
+            return False
+
+        goal_msg = GazeHead.Goal()
+        goal_msg.gaze_tf_name = gaze_tf_name
+
+        self._gaze_goal_handle = None
+        self._gaze_active = False
+
+        send_future = self.gaze_action_client.send_goal_async(goal_msg)
+        send_future.add_done_callback(self._gaze_goal_response_callback)
+        self.get_logger().info(
+            f"NavModule.->GazeHead goal sent (tf='{gaze_tf_name or 'default'}')")
+        return True
+
+    def cancel_gaze(self):
+        """Cancel the active GazeHead goal (no-op if none)."""
+        if self._gaze_goal_handle is not None:
+            self.get_logger().info('NavModule.->Canceling GazeHead goal')
+            self._gaze_goal_handle.cancel_goal_async()
+        self._gaze_goal_handle = None
+        self._gaze_active = False
+
+    def _set_move_head(self, enabled: bool, sync: bool = True):
+        """Enable or disable head commands from motion_synth via param_rw.
+
+        sync=False: fire-and-forget via call_async (safe to call inside
+                    go_abs() loop where spin_until_future_complete would
+                    conflict with the loop's local executor).
+        """
+        value = 'true' if enabled else 'false'
+        if sync:
+            self.call_param_rw(
+                node_name='head_controller',
+                param_name='move_head',
+                param_value=value,
+                write=True,
+            )
+        else:
+            req = ParamReadWrite.Request()
+            req.node_name = 'head_controller'
+            req.param_name = 'move_head'
+            req.write = True
+            req.value = value
+            self.param_rw_client.call_async(req)
+        self.get_logger().info(
+            f'NavModule.->head_controller move_head set to {value}')
+    # ----------------------------------
 
     def callback_stop(self, msg):
         self.robot_stop = True
@@ -324,6 +399,11 @@ class NavModule:
         self.motion_synth_end_pose = None
         self.motion_execution_time = 0.0
 
+        # Cancel any leftover gaze from a previous goal
+        if self._gaze_active:
+            self.cancel_gaze()
+            self._set_move_head(True)
+
     def go_abs(
         self,
         goal: Pose2D,
@@ -362,6 +442,16 @@ class NavModule:
         while rclpy.ok() and not self.robot_stop and attempts >= 0:
             if executor is not None:
                 executor.spin_once(timeout_sec=0.1)
+
+            # Cancel gaze when near_goal_reached fires in feedback so that
+            # motion_synth's end_pose can control the head without conflict.
+            # Checked before action_done so it fires even if both flags are
+            # set in the same spin cycle.
+            if self._gaze_active and self._action_near_goal:
+                self.get_logger().info(
+                    'NavModule.->near_goal_reached: canceling gaze, restoring move_head')
+                self.cancel_gaze()
+                self._set_move_head(True, sync=False)
 
             if self._action_done:
                 result = self._action_success
@@ -434,8 +524,17 @@ class NavModule:
         goal_distance=None,
         use_point_cloud=True,
         motion_execution_time=None,
+        gaze_point=False,
     ):
+        """Navigate to goal.
 
+        Args:
+            gaze_point: False → no gaze.  True → gaze using node's default
+                        gaze_tf_name param.  str → gaze using that TF name.
+                        When active, move_head on head_controller is set to
+                        False so motion_synth cannot override the head until
+                        gaze is cancelled near the goal.
+        """
         self.initialize_before_new_goal(send_stop=True)
 
         if motion_synth_pose is not None:
@@ -451,13 +550,28 @@ class NavModule:
             self.get_logger().info('NavModule.->Standard Nav Goal')
             self.set_use_point_cloud(use_point_cloud)
 
-        return self.go_abs(
+        # Start gaze if requested
+        if gaze_point is not False:
+            tf_name = gaze_point if isinstance(gaze_point, str) else ''
+            if self.start_gaze(tf_name):
+                self._set_move_head(False)
+
+        result = self.go_abs(
             goal,
             timeout,
             goal_distance,
             motion_synth=True,
             motion_execution_time=motion_execution_time,
         )
+
+        # Ensure gaze is cancelled and move_head restored after nav ends
+        if self._gaze_active:
+            self.get_logger().info(
+                'NavModule.->Nav ended: canceling gaze (fallback), restoring move_head')
+            self.cancel_gaze()
+            self._set_move_head(True)
+
+        return result
 
 
 if __name__ == '__main__':

--- a/navigation_tools/navigation_tools/navlib.py
+++ b/navigation_tools/navigation_tools/navlib.py
@@ -62,10 +62,7 @@ class NavModule:
 
         self.motion_synth_start_pose = None
         self.motion_synth_end_pose = None
-        # Forwarded to StartAndEndJoints.motion_execution_time →
-        # MotionSynthesis.motion_execution_time → arm/head goal_pose_time.
-        # 0.0 means "use server default (0.5 s)".
-        self.motion_execution_time = 0.0
+        self.motion_execution_time = 0.0  # for motion_synth arm/head reached time
 
         # Publishers
         self.pub_marker = self.create_publisher(Marker, '/nav_goal_marker', 10)
@@ -109,7 +106,14 @@ class NavModule:
     def __getattr__(self, name):
         return getattr(self._node, name)
 
-    def call_param_rw(self, node_name, param_name, param_value: str = '', write: bool = False):
+    def call_param_rw(
+        self,
+        node_name,
+        param_name,
+        param_value: str = '',
+        write: bool = False,
+        timeout_sec: float = 3.0,
+    ):
         req = ParamReadWrite.Request()
         req.node_name = node_name
         req.param_name = param_name
@@ -119,16 +123,17 @@ class NavModule:
         future = self.param_rw_client.call_async(req)
 
         if self._external_node:
-            # External executor is spinning this node; do not spin again
-            # (spin_until_future_complete would deadlock). Wait for the
-            # done-callback to fire from the external spinner's thread.
             done = threading.Event()
             future.add_done_callback(lambda _f: done.set())
-            if not done.wait(timeout=10.0):
+            if not done.wait(timeout=timeout_sec):
                 self.get_logger().error('NavModule.->param_read_write call timed out')
                 return None
         else:
-            rclpy.spin_until_future_complete(self._node, future)
+            rclpy.spin_until_future_complete(
+                self._node, future, timeout_sec=timeout_sec)
+            if not future.done():
+                self.get_logger().error('NavModule.->param_read_write call timed out')
+                return None
 
         if future.result() is not None:
             return future.result().param_value
@@ -149,8 +154,7 @@ class NavModule:
     def nav_feedback_callback(self, feedback_msg):
         feedback = feedback_msg.feedback
         self._action_feedback = feedback
-        # Latch near_goal flag from feedback so go_abs() can cancel gaze
-        # mid-navigation before the result arrives.
+
         if feedback.near_goal_reached:
             self._action_near_goal = True
         self.get_logger().info(
@@ -186,7 +190,6 @@ class NavModule:
             self.get_logger().warn('NavModule.->Canceling PumasNav goal')
             self._goal_handle.cancel_goal_async()
 
-    # ---------- Gaze management ----------
     def _gaze_goal_response_callback(self, future):
         goal_handle = future.result()
         if goal_handle is None or not goal_handle.accepted:
@@ -198,11 +201,8 @@ class NavModule:
         self.get_logger().info('NavModule.->GazeHead goal accepted, gaze active')
 
     def start_gaze(self, gaze_tf_name: str = '') -> bool:
-        """Send a GazeHead goal (fire-and-forget). Returns False when the
-        action server is unreachable within 3 s."""
         if not self.gaze_action_client.wait_for_server(timeout_sec=3.0):
-            self.get_logger().warn(
-                'NavModule.->GazeHead action server not available')
+            self.get_logger().warn('NavModule.->GazeHead action server not available')
             return False
 
         goal_msg = GazeHead.Goal()
@@ -218,7 +218,6 @@ class NavModule:
         return True
 
     def cancel_gaze(self):
-        """Cancel the active GazeHead goal (no-op if none)."""
         if self._gaze_goal_handle is not None:
             self.get_logger().info('NavModule.->Canceling GazeHead goal')
             self._gaze_goal_handle.cancel_goal_async()
@@ -226,30 +225,43 @@ class NavModule:
         self._gaze_active = False
 
     def _set_move_head(self, enabled: bool, sync: bool = True):
-        """Enable or disable head commands from motion_synth via param_rw.
-
-        sync=False: fire-and-forget via call_async (safe to call inside
-                    go_abs() loop where spin_until_future_complete would
-                    conflict with the loop's local executor).
-        """
         value = 'true' if enabled else 'false'
-        if sync:
-            self.call_param_rw(
-                node_name='head_controller',
-                param_name='move_head',
-                param_value=value,
-                write=True,
-            )
-        else:
-            req = ParamReadWrite.Request()
-            req.node_name = 'head_controller'
-            req.param_name = 'move_head'
-            req.write = True
-            req.value = value
-            self.param_rw_client.call_async(req)
+        for node_name in ('head_controller', 'simple_move'):
+            if sync:
+                self.call_param_rw(
+                    node_name=node_name,
+                    param_name='move_head',
+                    param_value=value,
+                    write=True,
+                )
+            else:
+                req = ParamReadWrite.Request()
+                req.node_name = node_name
+                req.param_name = 'move_head'
+                req.write = True
+                req.value = value
+                self.param_rw_client.call_async(req)
         self.get_logger().info(
-            f'NavModule.->head_controller move_head set to {value}')
-    # ----------------------------------
+            f'NavModule.->move_head set to {value} (head_controller, simple_move)'
+        )
+
+    def _set_use_point_cloud(self, enabled: bool):
+        value = 'true' if enabled else 'false'
+
+        self.call_param_rw(
+            node_name='potential_fields',
+            param_name='use_point_cloud',
+            param_value=value,
+            write=True,
+        )
+        self.call_param_rw(
+            node_name='map_augmenter',
+            param_name='use_point_cloud',
+            param_value=value,
+            write=True,
+        )
+
+        self.get_logger().info(f'NavModule.->use_point_cloud set to {value}')
 
     def callback_stop(self, msg):
         self.robot_stop = True
@@ -298,19 +310,6 @@ class NavModule:
         joints.head_pan_joint = joint_poses['head_pan_joint']
         joints.head_tilt_joint = joint_poses['head_tilt_joint']
         return joints
-
-    # def create_goal_pose(self, x, y, yaw, frame_id):
-    #    goal = PoseStamped()
-    #    goal.header.frame_id = frame_id
-    #    goal.pose.position.x = x
-    #    goal.pose.position.y = y
-    #    goal.pose.position.z = 0.0
-    #    q = quaternion_from_euler(0, 0, yaw)
-    #    goal.pose.orientation.x = q[0]
-    #    goal.pose.orientation.y = q[1]
-    #    goal.pose.orientation.z = q[2]
-    #    goal.pose.orientation.w = q[3]
-    #    return goal
 
     def send_nav_action_goal(self, goal: Pose2D):
         if not self.nav_action_client.wait_for_server(timeout_sec=3.0):
@@ -443,13 +442,10 @@ class NavModule:
             if executor is not None:
                 executor.spin_once(timeout_sec=0.1)
 
-            # Cancel gaze when near_goal_reached fires in feedback so that
-            # motion_synth's end_pose can control the head without conflict.
-            # Checked before action_done so it fires even if both flags are
-            # set in the same spin cycle.
             if self._gaze_active and self._action_near_goal:
                 self.get_logger().info(
-                    'NavModule.->near_goal_reached: canceling gaze, restoring move_head')
+                    'NavModule.->near_goal_reached: canceling gaze, restoring move_head'
+                )
                 self.cancel_gaze()
                 self._set_move_head(True, sync=False)
 
@@ -498,24 +494,6 @@ class NavModule:
 
         return result
 
-    def set_use_point_cloud(self, enabled: bool):
-        value = 'true' if enabled else 'false'
-
-        self.call_param_rw(
-            node_name='potential_fields',
-            param_name='use_point_cloud',
-            param_value=value,
-            write=True,
-        )
-        self.call_param_rw(
-            node_name='map_augmenter',
-            param_name='use_point_cloud',
-            param_value=value,
-            write=True,
-        )
-
-        self.get_logger().info(f'NavModule.->use_point_cloud set to {value}')
-
     def nav_goal(
         self,
         goal,
@@ -526,20 +504,11 @@ class NavModule:
         motion_execution_time=None,
         gaze_point=False,
     ):
-        """Navigate to goal.
-
-        Args:
-            gaze_point: False → no gaze.  True → gaze using node's default
-                        gaze_tf_name param.  str → gaze using that TF name.
-                        When active, move_head on head_controller is set to
-                        False so motion_synth cannot override the head until
-                        gaze is cancelled near the goal.
-        """
         self.initialize_before_new_goal(send_stop=True)
 
         if motion_synth_pose is not None:
             self.get_logger().info('NavModule.->Motion Synth Nav Goal with Pose Config')
-            self.set_use_point_cloud(False)
+            self._set_use_point_cloud(False)
 
             if 'start' in motion_synth_pose:
                 self.motion_synth_start_pose = motion_synth_pose['start']
@@ -548,9 +517,11 @@ class NavModule:
 
         else:
             self.get_logger().info('NavModule.->Standard Nav Goal')
-            self.set_use_point_cloud(use_point_cloud)
+            if gaze_point is not False:
+                self._set_use_point_cloud(False)
+            else:
+                self._set_use_point_cloud(use_point_cloud)
 
-        # Start gaze if requested
         if gaze_point is not False:
             tf_name = gaze_point if isinstance(gaze_point, str) else ''
             if self.start_gaze(tf_name):
@@ -567,7 +538,8 @@ class NavModule:
         # Ensure gaze is cancelled and move_head restored after nav ends
         if self._gaze_active:
             self.get_logger().info(
-                'NavModule.->Nav ended: canceling gaze (fallback), restoring move_head')
+                'NavModule.->Nav ended: canceling gaze (fallback), restoring move_head'
+            )
             self.cancel_gaze()
             self._set_move_head(True)
 
@@ -603,10 +575,19 @@ if __name__ == '__main__':
         'goal': goal_pose,
     }
 
+    # for gaze node test
+    gaze_tf = 'gaze_point'
+    gaze_tf = False
+
     # goal = Pose2D(x=2.58, y=2.0, theta=0.0)
-    goal = Pose2D(x=5.7, y=0.4, theta=0.0)
+    goal = Pose2D(x=1.4, y=3.6, theta=0.0)
+    goal = Pose2D(x=0.0, y=0.0, theta=0.0)
     success = nav.nav_goal(
-        goal, motion_synth_pose=ms_config, timeout=0, goal_distance=None, motion_execution_time=0.2
+        goal,
+        motion_synth_pose=None,
+        timeout=0,
+        goal_distance=None,
+        motion_execution_time=0.2,
     )
 
     # goal = Pose2D(x=0.0, y=0.0, theta=0.0)

--- a/pumas_interfaces/CMakeLists.txt
+++ b/pumas_interfaces/CMakeLists.txt
@@ -29,6 +29,7 @@ set(srv_files
 set(action_files
   "action/MotionSynthesis.action"
   "action/PumasNav.action"
+  "action/GazeHead.action"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/pumas_interfaces/action/GazeHead.action
+++ b/pumas_interfaces/action/GazeHead.action
@@ -1,0 +1,9 @@
+# Goal
+string gaze_tf_name   # target TF frame name; empty string → use node param gaze_tf_name
+---
+# Result
+bool success
+---
+# Feedback
+float32 pan
+float32 tilt


### PR DESCRIPTION
This PR adds gaze control during navigation，allowing the robot head to track a target TF frame．It introduces a new gaze_node and GazeHead action，integrates gaze control into navlib，and adds a move_head switch to prevent conflicts with motion_synth．
